### PR TITLE
Updated libraries to API 28 (AndroidX)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,6 +2,12 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 28
+    /* Java 8 support is needed for ExoPlayer 2.10.5
+     * Source : https://github.com/google/ExoPlayer/issues/5276
+    * */
+    compileOptions {
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
     defaultConfig {
         applicationId "io.r_a_d.radio"
         minSdkVersion 16
@@ -25,9 +31,9 @@ dependencies {
     androidTestImplementation('androidx.test.espresso:espresso-core:3.1.0', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    implementation 'androidx.appcompat:appcompat:1.0.0'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'com.google.android.material:material:1.0.0'
-    implementation 'com.google.android.exoplayer:exoplayer:2.7.2'
+    implementation 'com.google.android.exoplayer:exoplayer:2.10.5'
     testImplementation 'junit:junit:4.12'
 
     // adding media dependency from Google Maven repository. From:
@@ -35,3 +41,4 @@ dependencies {
     def media_version = "1.1.0"
     implementation "androidx.media:media:$media_version"
 }
+

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
     defaultConfig {
         applicationId "io.r_a_d.radio"
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionName '1.2.1.2'
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         versionCode 9
     }
     buildTypes {
@@ -22,11 +22,16 @@ android {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
+    androidTestImplementation('androidx.test.espresso:espresso-core:3.1.0', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    implementation 'com.android.support:appcompat-v7:27.1.0'
-    implementation 'com.android.support:design:27.1.0'
+    implementation 'androidx.appcompat:appcompat:1.0.0'
+    implementation 'com.google.android.material:material:1.0.0'
     implementation 'com.google.android.exoplayer:exoplayer:2.7.2'
     testImplementation 'junit:junit:4.12'
+
+    // adding media dependency from Google Maven repository. From:
+    // https://developer.android.com/jetpack/androidx/releases/media/
+    def media_version = "1.1.0"
+    implementation "androidx.media:media:$media_version"
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,7 +33,7 @@
                 <action android:name="android.media.browse.MediaBrowserService" />
             </intent-filter>
         </service>
-        <receiver android:name="android.support.v4.media.session.MediaButtonReceiver" >
+        <receiver android:name="androidx.core.media.session.MediaButtonReceiver" >
             <intent-filter>
                 <action android:name="android.intent.action.MEDIA_BUTTON" />
             </intent-filter>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.BLUETOOTH" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" /> <!-- needed for API 28-->
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
@@ -33,7 +34,7 @@
                 <action android:name="android.media.browse.MediaBrowserService" />
             </intent-filter>
         </service>
-        <receiver android:name="androidx.core.media.session.MediaButtonReceiver" >
+        <receiver android:name="androidx.media.session.MediaButtonReceiver" >
             <intent-filter>
                 <action android:name="android.intent.action.MEDIA_BUTTON" />
             </intent-filter>

--- a/app/src/main/java/io/r_a_d/radio/ActivityMain.java
+++ b/app/src/main/java/io/r_a_d/radio/ActivityMain.java
@@ -8,12 +8,14 @@ import android.graphics.Rect;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.IBinder;
-import android.support.design.widget.TabLayout;
-import android.support.v4.content.res.ResourcesCompat;
-import android.support.v4.graphics.drawable.RoundedBitmapDrawable;
-import android.support.v4.view.ViewPager;
-import android.support.v4.widget.DrawerLayout;
-import android.support.v7.app.AppCompatActivity;
+// migrated class mappings to androidx with:
+// https://developer.android.com/jetpack/androidx/migrate/class-mappings
+import com.google.android.material.tabs.TabLayout;
+import androidx.core.content.res.ResourcesCompat;
+import androidx.core.graphics.drawable.RoundedBitmapDrawable;
+import androidx.viewpager.widget.ViewPager;
+import androidx.drawerlayout.widget.DrawerLayout;
+import androidx.appcompat.app.AppCompatActivity;
 import android.text.Html;
 import android.text.TextUtils;
 import android.text.method.LinkMovementMethod;

--- a/app/src/main/java/io/r_a_d/radio/CustomPagerAdapter.java
+++ b/app/src/main/java/io/r_a_d/radio/CustomPagerAdapter.java
@@ -5,7 +5,7 @@ package io.r_a_d.radio;
  */
 
 import android.content.Context;
-import android.support.v4.view.PagerAdapter;
+import androidx.viewpager.widget.PagerAdapter;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;

--- a/app/src/main/java/io/r_a_d/radio/DJImageTask.java
+++ b/app/src/main/java/io/r_a_d/radio/DJImageTask.java
@@ -1,8 +1,8 @@
 package io.r_a_d.radio;
 
 import android.os.AsyncTask;
-import android.support.v4.graphics.drawable.RoundedBitmapDrawable;
-import android.support.v4.graphics.drawable.RoundedBitmapDrawableFactory;
+import androidx.core.graphics.drawable.RoundedBitmapDrawable;
+import androidx.core.graphics.drawable.RoundedBitmapDrawableFactory;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/app/src/main/java/io/r_a_d/radio/RadioService.java
+++ b/app/src/main/java/io/r_a_d/radio/RadioService.java
@@ -447,7 +447,8 @@ public class RadioService extends MediaBrowserServiceCompat {
     }
 
     private void createMediaPlayer() {
-        sep = ExoPlayerFactory.newSimpleInstance(
+        // new prototype for ExoPlayer 2.10.5 : needs context (this)
+        sep = ExoPlayerFactory.newSimpleInstance(this,
                 new DefaultRenderersFactory(this),
                 new DefaultTrackSelector(),
                 new DefaultLoadControl());

--- a/app/src/main/java/io/r_a_d/radio/RadioService.java
+++ b/app/src/main/java/io/r_a_d/radio/RadioService.java
@@ -20,12 +20,12 @@ import android.os.IBinder;
 import android.os.PowerManager;
 import android.os.SystemClock;
 import android.os.Handler;
-import android.support.annotation.RequiresApi;
-import android.support.v4.app.NotificationCompat;
+import androidx.annotation.RequiresApi;
+import androidx.core.app.NotificationCompat;
 import android.support.v4.media.MediaBrowserCompat;
-import android.support.v4.media.MediaBrowserServiceCompat;
+import androidx.media.MediaBrowserServiceCompat;
 import android.support.v4.media.MediaMetadataCompat;
-import android.support.v4.media.session.MediaButtonReceiver;
+import androidx.media.session.MediaButtonReceiver;
 import android.support.v4.media.session.MediaSessionCompat;
 import android.support.v4.media.session.PlaybackStateCompat;
 import android.telephony.PhoneStateListener;
@@ -157,7 +157,7 @@ public class RadioService extends MediaBrowserServiceCompat {
 
         PowerManager powerManager = (PowerManager) getSystemService(POWER_SERVICE);
         if (powerManager != null)
-            wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "KilimDankLock");
+            wakeLock = powerManager.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "lock:KilimDankLock");
 
         WifiManager wifiManager = (WifiManager) getApplicationContext().getSystemService(Context.WIFI_SERVICE);
         if (wifiManager != null)
@@ -269,7 +269,7 @@ public class RadioService extends MediaBrowserServiceCompat {
             m_builder.setVisibility(NotificationCompat.VISIBILITY_PUBLIC);
         }
 
-        m_builder.setStyle(new android.support.v4.media.app.NotificationCompat.MediaStyle()
+        m_builder.setStyle(new androidx.media.app.NotificationCompat.MediaStyle()
                 .setMediaSession(m_mediaSession.getSessionToken())
                 .setShowActionsInCompactView(0));
 
@@ -447,7 +447,8 @@ public class RadioService extends MediaBrowserServiceCompat {
     }
 
     private void createMediaPlayer() {
-        sep = ExoPlayerFactory.newSimpleInstance(new DefaultRenderersFactory(this),
+        sep = ExoPlayerFactory.newSimpleInstance(
+                new DefaultRenderersFactory(this),
                 new DefaultTrackSelector(),
                 new DefaultLoadControl());
     }

--- a/app/src/main/java/io/r_a_d/radio/SongAdapter.java
+++ b/app/src/main/java/io/r_a_d/radio/SongAdapter.java
@@ -1,7 +1,7 @@
 package io.r_a_d.radio;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;

--- a/app/src/main/res/layout/homescreen.xml
+++ b/app/src/main/res/layout/homescreen.xml
@@ -1,4 +1,4 @@
-<android.support.v4.widget.DrawerLayout
+<androidx.drawerlayout.widget.DrawerLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
@@ -66,7 +66,7 @@
                     android:gravity="center_vertical"
                     android:paddingStart="12dp" />
 
-                <android.support.design.widget.TabLayout
+                <com.google.android.material.tabs.TabLayout
                     android:layout_height="wrap_content"
                     android:id="@+id/tab_dots"
                     app:tabIndicatorHeight="0dp"
@@ -91,7 +91,7 @@
             android:layout_height="match_parent"
             android:id="@+id/main_screen">
 
-            <android.support.v4.view.ViewPager
+            <androidx.viewpager.widget.ViewPager
                 android:id="@+id/viewpager"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
@@ -121,4 +121,4 @@
             layout="@layout/queue_lp" />
     </LinearLayout>
 
-</android.support.v4.widget.DrawerLayout>
+</androidx.drawerlayout.widget.DrawerLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.0'
+        classpath 'com.android.tools.build:gradle:3.5.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,7 @@ org.gradle.jvmargs=-Xmx1536m
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+
+
+android.useAndroidX=true
+android.enableJetifier=true


### PR DESCRIPTION
I updated the libraries call to the latest common Android library called "Jetpack". It supports the global package "Android X" where all further development is now concentrated.

See more here : https://developer.android.com/jetpack/androidx

This was in particular useful to update ExoPlayer to the new version 2.10.5. This version supports much more features, in particular metadata parsing for SHOUTcast streams and special media notifications.

The rest of the app is left how it is, but I would suggest to rewrite some parts of it to ease up future developments and fix current bugs that may arise.

Concerning the content of the PR, no feature has been added, but the app now uses a more recent code base and can support further development.